### PR TITLE
rename proxy_set_tick_period to reflect resolution

### DIFF
--- a/abi-versions/vNEXT/README.md
+++ b/abi-versions/vNEXT/README.md
@@ -435,7 +435,7 @@ used after returning `false` in `proxy_on_done`.
 
 ## Timers
 
-### `proxy_set_tick_period`
+### `proxy_set_tick_period_milliseconds`
 
 * params:
   - `i32 (uint32_t) tick_period`


### PR DESCRIPTION
this function is named proxy_set_tick_period_milliseconds at other parts of the spec and across implementations