### PR TITLE
Remove the link to Zig SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Proxy-Wasm extensions across different proxies.
 * [C++ SDK]
 * [Go (TinyGo) SDK]
 * [Rust SDK]
-* [Zig SDK]
 
 [AssemblyScript SDK]: https://github.com/solo-io/proxy-runtime
 [C++ SDK]: https://github.com/proxy-wasm/proxy-wasm-cpp-sdk

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Proxy-Wasm extensions across different proxies.
 [C++ SDK]: https://github.com/proxy-wasm/proxy-wasm-cpp-sdk
 [Go (TinyGo) SDK]: https://github.com/tetratelabs/proxy-wasm-go-sdk
 [Rust SDK]: https://github.com/proxy-wasm/proxy-wasm-rust-sdk
-[Zig SDK]: https://github.com/mathetake/proxy-wasm-zig-sdk
 
 ### Host environments
 


### PR DESCRIPTION
The SDK has been archived, and won't be maintained anymore.