### PR TITLE
Update status of ATS and OpenResty host implementations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,14 @@ Proxy-Wasm extensions across different proxies.
 
 #### Servers
 
+* [ATS]
 * [Envoy]
-* [Istio Proxy] (Envoy-based)
 * [MOSN]
-* [ATS] (work-in-progress)
-* [OpenResty] (work-in-progress)
+* [OpenResty]
 
-[Envoy]: https://github.com/envoyproxy/envoy
-[Istio Proxy]: https://github.com/istio/proxy
-[MOSN]: https://github.com/mosn/mosn
 [ATS]: https://docs.trafficserver.apache.org/en/latest/admin-guide/plugins/wasm.en.html
+[Envoy]: https://github.com/envoyproxy/envoy
+[MOSN]: https://github.com/mosn/mosn
 [OpenResty]: https://github.com/api7/wasm-nginx-module
 
 #### Libraries


### PR DESCRIPTION
While there, drop link to Istio Proxy, since it's no different than other Envoy implementations.