### PR TITLE
Add certificate OID map properties to vNEXT spec

### DIFF
--- a/abi-versions/vNEXT/README.md
+++ b/abi-versions/vNEXT/README.md
@@ -1780,6 +1780,10 @@ Returned `status` value is:
   the peer certificate
 * `connection.sha256_peer_certificate_digest` (string) - SHA256 digest of
   the peer certificate
+* `connection.oid_map_local_certificate` (map) - map of all OIDs to their
+  values in the local certificate
+* `connection.oid_map_peer_certificate` (map) - map of all OIDs to their
+  values in the peer certificate
 
 
 #### Upstream connection properties
@@ -1803,6 +1807,10 @@ Returned `status` value is:
   the peer certificate
 * `upstream.sha256_peer_certificate_digest` (string) - SHA256 digest of
   the peer certificate
+* `upstream.oid_map_local_certificate` (map) - map of all OIDs to their
+  values in the local certificate
+* `upstream.oid_map_peer_certificate` (map) - map of all OIDs to their
+  values in the peer certificate
 
 
 #### HTTP request properties


### PR DESCRIPTION
 This PR addresses issue #88 by adding new properties to access certificate OIDs:

  - `connection.oid_map_local_certificate`
  - `connection.oid_map_peer_certificate`
  - `upstream.oid_map_local_certificate`
  - `upstream.oid_map_peer_certificate`

  These properties return maps of all OIDs to their corresponding values in certificates,
  allowing plugins to access all certificate properties including X.509 extensions that may not
  be exposed through the existing certificate properties.

  This enhancement will enable Proxy-WASM plugins to access additional certificate attributes
  needed for advanced use cases, particularly when working with certificates that contain
  non-standard X.509 extensions with custom OIDs.