### PR TITLE
Document how proxy_{get,set}_property expects paths to be serialized.

### DIFF
--- a/abi-versions/v0.2.0/README.md
+++ b/abi-versions/v0.2.0/README.md
@@ -1687,6 +1687,8 @@ Returned `status` value is:
 Retrieves value (`return_value_data`, `return_value_size`)
 of the property (`path_data`, `path_size`).
 
+`path_data` is a [serialized] list of path segments.
+
 Returned `status` value is:
 - `OK` on success.
 - `NOT_FOUND` when there was no property found at the requested `path`.
@@ -1708,6 +1710,8 @@ Returned `status` value is:
 
 Sets value of the property (`path_data`, `path_size`) to the provided
 value (`value_data`, `value_size`).
+
+`path_data` is a [serialized] list of path segments.
 
 Returned `status` value is:
 - `OK` on success.
@@ -1919,6 +1923,18 @@ e.g. the map `{{"a": "1"}, {"b": "22"}}` would be serialized as:
 
 An empty map may be represented either as an empty value (`size=0`), or as
 a single `0x00` byte (`size=1`).
+
+#### Property path names
+
+Path data for the [proxy_get_property] and [property_set_property] hostcalls
+consists of a sequence of path segments. The path segments are separated by
+`NULL` (`0x00`) characters.
+
+e.g. the path segments `["foo", "bar"]` would be serialized as:
+-  `0x66`, `0x6f`, `0x6f`, `0x00`, `0x62`, `0x61`, `0x72`
+
+Host implementations should tolerate a `NULL` character at the end of the
+combined path data string, if present.
 
 
 # Security Considerations

--- a/abi-versions/v0.2.1/README.md
+++ b/abi-versions/v0.2.1/README.md
@@ -1710,6 +1710,8 @@ Returned `status` value is:
 Retrieves value (`return_value_data`, `return_value_size`)
 of the property (`path_data`, `path_size`).
 
+`path_data` is a [serialized] list of path segments.
+
 Returned `status` value is:
 - `OK` on success.
 - `NOT_FOUND` when there was no property found at the requested `path`.
@@ -1731,6 +1733,8 @@ Returned `status` value is:
 
 Sets value of the property (`path_data`, `path_size`) to the provided
 value (`value_data`, `value_size`).
+
+`path_data` is a [serialized] list of path segments.
 
 Returned `status` value is:
 - `OK` on success.
@@ -1943,6 +1947,14 @@ e.g. the map `{{"a": "1"}, {"b": "22"}}` would be serialized as:
 An empty map may be represented either as an empty value (`size=0`), or as
 a single `0x00` byte (`size=1`).
 
+#### Property path names
+
+Path data for the [proxy_get_property] and [property_set_property] hostcalls
+consists of a sequence of path segments. The path segments are null-terminated
+and then concatenated in sequence to form the `path_data` argument.
+
+e.g. the path segments `["foo", "bar"]` would be serialized as:
+-  `0x66`, `0x6f`, `0x6f`, `0x00`, `0x62`, `0x61`, `0x72`, `0x00`
 
 # Security Considerations
 

--- a/abi-versions/v0.2.1/README.md
+++ b/abi-versions/v0.2.1/README.md
@@ -1959,6 +1959,7 @@ e.g. the path segments `["foo", "bar"]` would be serialized as:
 Host implementations should tolerate a `NULL` character at the end of the
 combined path data string, if present.
 
+
 # Security Considerations
 
 ## External resources

--- a/abi-versions/v0.2.1/README.md
+++ b/abi-versions/v0.2.1/README.md
@@ -1950,11 +1950,14 @@ a single `0x00` byte (`size=1`).
 #### Property path names
 
 Path data for the [proxy_get_property] and [property_set_property] hostcalls
-consists of a sequence of path segments. The path segments are null-terminated
-and then concatenated in sequence to form the `path_data` argument.
+consists of a sequence of path segments. The path segments are separated by
+`NULL` (`0x00`) characters.
 
 e.g. the path segments `["foo", "bar"]` would be serialized as:
--  `0x66`, `0x6f`, `0x6f`, `0x00`, `0x62`, `0x61`, `0x72`, `0x00`
+-  `0x66`, `0x6f`, `0x6f`, `0x00`, `0x62`, `0x61`, `0x72`
+
+Host implementations should tolerate a `NULL` character at the end of the
+combined path data string, if present.
 
 # Security Considerations
 

--- a/abi-versions/vNEXT/README.md
+++ b/abi-versions/vNEXT/README.md
@@ -1710,6 +1710,8 @@ Returned `status` value is:
 Retrieves value (`return_value_data`, `return_value_size`)
 of the property (`path_data`, `path_size`).
 
+`path_data` is a [serialized] list of path segments.
+
 Returned `status` value is:
 - `OK` on success.
 - `NOT_FOUND` when there was no property found at the requested `path`.
@@ -1731,6 +1733,8 @@ Returned `status` value is:
 
 Sets value of the property (`path_data`, `path_size`) to the provided
 value (`value_data`, `value_size`).
+
+`path_data` is a [serialized] list of path segments.
 
 Returned `status` value is:
 - `OK` on success.
@@ -1942,6 +1946,18 @@ e.g. the map `{{"a": "1"}, {"b": "22"}}` would be serialized as:
 
 An empty map may be represented either as an empty value (`size=0`), or as
 a single `0x00` byte (`size=1`).
+
+#### Property path names
+
+Path data for the [proxy_get_property] and [property_set_property] hostcalls
+consists of a sequence of path segments. The path segments are separated by
+`NULL` (`0x00`) characters.
+
+e.g. the path segments `["foo", "bar"]` would be serialized as:
+-  `0x66`, `0x6f`, `0x6f`, `0x00`, `0x62`, `0x61`, `0x72`
+
+Host implementations should tolerate a `NULL` character at the end of the
+combined path data string, if present.
 
 
 # Security Considerations


### PR DESCRIPTION
Document the de-facto serialization format used by the various proxy-wasm SDKs ([C++](https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/blob/e5256b0c5463ea9961965ad5de3e379e00486640/proxy_wasm_api.h#L931-L943), [Rust](https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/ba23ab402e3c2a1fcaa9592d8204333d7b6ae46f/src/hostcalls.rs#L1211-L1226), [Go](https://github.com/proxy-wasm/proxy-wasm-go-sdk/blob/ab4161dcf9246a828008b539a82a1556cf0f2e24/proxywasm/internal/serde.go#L78-L96)) to serialize `path_data` arguments for the `proxy_get_property` and `proxy_set_property` hostcalls.